### PR TITLE
Add support for namespaces

### DIFF
--- a/test/resources/namespaces.js
+++ b/test/resources/namespaces.js
@@ -1,0 +1,8 @@
+const ns1 = require("./ns1");
+const ns2 = require("./ns2");
+const ns3 = require("./ns3");
+const ns4 = require("./ns4");
+
+module.exports = {
+  namespaces: { ns1, ns2, ns3, ns4 },
+};

--- a/test/resources/ns1.js
+++ b/test/resources/ns1.js
@@ -1,0 +1,22 @@
+module.exports = [
+  {
+    code: "error.code.login.failed",
+    tr: [
+      {
+        l: "en",
+        v: "Access denied. Please check your credentials and retry",
+      },
+      {
+        l: "it",
+        v: "Accesso negato. Controllare le credenziali e riprovare",
+      },
+    ],
+  },
+  {
+    code: "http.error.code.400",
+    tr: [
+      { l: "en", v: "Sorry, the request is wrong (400)" },
+      { l: "it", v: "Siamo spiacenti, la richiesta è errata (400)" },
+    ],
+  },
+];

--- a/test/resources/ns2.js
+++ b/test/resources/ns2.js
@@ -1,0 +1,23 @@
+module.exports = [
+  {
+    code: "http.error.code.generic",
+    tr: [
+      { l: "en", v: "Generic comunication error" },
+      { l: "it", v: "Errore di comunicazione generica" },
+    ],
+  },
+  {
+    code: "I18N_SELECTED",
+    tr: [
+      { l: "en", v: "Selected" },
+      { l: "it", v: "Selezionati" },
+    ],
+  },
+  {
+    code: "I18N_SIGN_IN",
+    tr: [
+      { l: "en", v: "Sign in" },
+      { l: "it", v: "Collegati" },
+    ],
+  },
+];

--- a/test/resources/ns3.js
+++ b/test/resources/ns3.js
@@ -1,0 +1,16 @@
+module.exports = [
+  {
+    code: "I18N_TABLE_ACTIONS",
+    tr: [
+      { l: "en", v: "Actions" },
+      { l: "it", v: "Operazioni" },
+    ],
+  },
+  {
+    code: "I18N_USER",
+    tr: [
+      { l: "en", v: "User" },
+      { l: "it", v: "Utente" },
+    ],
+  },
+];

--- a/test/resources/ns4.js
+++ b/test/resources/ns4.js
@@ -1,0 +1,30 @@
+module.exports = [
+  {
+    code: "i18n.codes.defect.severity.AVERAGE",
+    tr: [
+      { l: "en", v: "Average" },
+      { l: "it", v: "Medio" },
+    ],
+  },
+  {
+    code: "i18n.codes.defect.severity.SEVERE",
+    tr: [
+      { l: "en", v: "Severe" },
+      { l: "it", v: "Grave" },
+    ],
+  },
+  {
+    code: "i18n.codes.defect.severity.SLIGHT",
+    tr: [
+      { l: "en", v: "Slight" },
+      { l: "it", v: "Lieve" },
+    ],
+  },
+  {
+    code: "i18n.codes.defect.types.OTHERS",
+    tr: [
+      { l: "en", v: "Others" },
+      { l: "it", v: "Altro" },
+    ],
+  },
+];


### PR DESCRIPTION
This PR add namespaces support allowing user to use multiple file as input and generate different files as output.

Scenario:
we have multiple translations files, for example:
```js
// ns1.js
module.exports = [
  {
    code: "error.code.login.failed",
    tr: [
      {
        l: "en",
        v: "Access denied. Please check your credentials and retry",
      },
      {
        l: "it",
        v: "Accesso negato. Controllare le credenziali e riprovare",
      },
    ],
  },
  {
    code: "http.error.code.400",
    tr: [
      { l: "en", v: "Sorry, the request is wrong (400)" },
      { l: "it", v: "Siamo spiacenti, la richiesta è errata (400)" },
    ],
  },
];
```
and
```js
// ns2.js
module.exports = [
  {
    code: "i18n.codes.defect.severity.AVERAGE",
    tr: [
      { l: "en", v: "Average" },
      { l: "it", v: "Medio" },
    ],
  },
  {
    code: "i18n.codes.defect.severity.SEVERE",
    tr: [
      { l: "en", v: "Severe" },
      { l: "it", v: "Grave" },
    ],
  },
];
```
we can use an input file exporting an object with the `namespace` key  which contains all the namespaces we want to create like this:
```js
// input.js
const ns1 = require("./ns1");
const ns2 = require("./ns2");

module.exports = {
  namespaces: { ns1, ns2 },
};
```

running the `i18nMsg` script will produce the following files:
```
─ i18nMessages.ts       // export * from './ns1' ...
─ ns1.ts                // export const httpErrorCode400 = "http.error.code.400" ...
─ ns2.ts                // export const i18nCodesDefectSeverityAVERAGE = "i18n.codes.defect.severity.AVERAGE" ...
─ ns1-sort-temp.json    // sorted files
─ ns2-sort-temp.json    // sorted files
─ en                    // english translations
  ├── ns1.json          
  └── ns2.json
─ it                    // italian translations
  ├── ns1.json
  └── ns2.json
```

Backward compatibility is kept with previous input format, namespaces feature is triggered only when the input file has a valid `namspaces` key.

